### PR TITLE
temporary fix for workflow while reviewing block generation flow

### DIFF
--- a/merge_collection_metadata.py
+++ b/merge_collection_metadata.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     collections = {"collections": {}}
     for collection_dir in sorted(collection_dirs):
         # get the latest tag
-        path = sorted(collection_dir.glob("*"), reverse=True)[0]
+        path = sorted(collection_dir.glob("*.json"), reverse=True)[0]
         collections["collections"][collection_dir.stem] = json.loads(path.read_text())
     (Path("collections") / "collection_blocks_data.json").write_text(
         json.dumps(collections, indent=2)


### PR DESCRIPTION
with the merge of the flow metadata files, it started catching those dirs 