### PR TITLE
Makes `documentation_url` optional in block type schema

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -72,7 +72,6 @@ block_type_schema = {
         "name",
         "slug",
         "logo_url",
-        "documentation_url",
         "description",
         "code_example",
         "block_schema",


### PR DESCRIPTION
A lot of blocks are still missing a `documentation_url`, so we'll make that field optional for now.