### PR TITLE
Improve docstring parsing

### DIFF
--- a/collections/prefect-bitbucket/flows/v0.1.1.json
+++ b/collections/prefect-bitbucket/flows/v0.1.1.json
@@ -1,0 +1,3 @@
+{
+  "prefect-bitbucket": {}
+}

--- a/collections/prefect-kubernetes/flows/v0.2.1.json
+++ b/collections/prefect-kubernetes/flows/v0.2.1.json
@@ -1,0 +1,148 @@
+{
+  "prefect-kubernetes": {
+    "run_namespaced_job": {
+      "description": {
+        "summary": "Flow for running a namespaced Kubernetes job.",
+        "returns": "The a dict of logs from each pod in the job, e.g. {'pod_name': 'pod_log_str'}.",
+        "examples": [
+          "```python\nfrom prefect_kubernetes import KubernetesJob, run_namespaced_job\nfrom prefect_kubernetes.credentials import KubernetesCredentials\n\nrun_namespaced_job(\n    kubernetes_job=KubernetesJob.from_yaml_file(\n        credentials=KubernetesCredentials.load(\"k8s-creds\"),\n        manifest_path=\"path/to/job.yaml\",\n    )\n)\n```"
+        ]
+      },
+      "documentation_url": "https://prefecthq.github.io/prefect-kubernetes/flows/#prefect_kubernetes.flows.run_namespaced_job",
+      "entrypoint": "prefect_kubernetes/flows.py:run_namespaced_job",
+      "install_command": "pip install prefect-kubernetes",
+      "logo_url": "https://images.ctfassets.net/zscdif0zqppk/oYuHjIbc26oilfQSEMjRv/a61f5f6ef406eead2df5231835b4c4c2/logo.png?h=250",
+      "name": "run-namespaced-job",
+      "parameters": {
+        "title": "Parameters",
+        "type": "object",
+        "properties": {
+          "kubernetes_job": {
+            "title": "kubernetes_job",
+            "description": "The `KubernetesJob` block that specifies the job to run.",
+            "position": 0,
+            "allOf": [
+              {
+                "$ref": "#/definitions/KubernetesJob"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kubernetes_job"
+        ],
+        "definitions": {
+          "KubernetesClusterConfig": {
+            "title": "KubernetesClusterConfig",
+            "description": "Stores configuration for interaction with Kubernetes clusters.\n\nSee `from_file` for creation.",
+            "type": "object",
+            "properties": {
+              "config": {
+                "title": "Config",
+                "description": "The entire contents of a kubectl config file.",
+                "type": "object"
+              },
+              "context_name": {
+                "title": "Context Name",
+                "description": "The name of the kubectl context to use.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "config",
+              "context_name"
+            ],
+            "block_type_slug": "kubernetes-cluster-config",
+            "secret_fields": [],
+            "block_schema_references": {}
+          },
+          "KubernetesCredentials": {
+            "title": "KubernetesCredentials",
+            "description": "Credentials block for generating configured Kubernetes API clients.",
+            "type": "object",
+            "properties": {
+              "cluster_config": {
+                "$ref": "#/definitions/KubernetesClusterConfig"
+              }
+            },
+            "block_type_slug": "kubernetes-credentials",
+            "secret_fields": [],
+            "block_schema_references": {
+              "cluster_config": {
+                "block_type_slug": "kubernetes-cluster-config",
+                "block_schema_checksum": "sha256:90d421e948bfbe4cdc98b124995f0edd0f84b0837549ad1390423bad8e31cf3b"
+              }
+            }
+          },
+          "KubernetesJob": {
+            "title": "KubernetesJob",
+            "description": "A block representing a Kubernetes job configuration.",
+            "type": "object",
+            "properties": {
+              "v1_job": {
+                "title": "Job Manifest",
+                "description": "The Kubernetes job manifest to run. This dictionary can be produced using `yaml.safe_load`.",
+                "type": "object"
+              },
+              "api_kwargs": {
+                "title": "Additional API Arguments",
+                "description": "Additional arguments to include in Kubernetes API calls.",
+                "example": {
+                  "pretty": "true"
+                },
+                "type": "object"
+              },
+              "credentials": {
+                "title": "Credentials",
+                "description": "The credentials to configure a client from.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/KubernetesCredentials"
+                  }
+                ]
+              },
+              "delete_after_completion": {
+                "title": "Delete After Completion",
+                "description": "Whether to delete the job after it has completed.",
+                "default": true,
+                "type": "boolean"
+              },
+              "interval_seconds": {
+                "title": "Interval Seconds",
+                "description": "The number of seconds to wait between job status checks.",
+                "default": 5,
+                "type": "integer"
+              },
+              "namespace": {
+                "title": "Namespace",
+                "description": "The namespace to create and run the job in.",
+                "default": "default",
+                "type": "string"
+              },
+              "timeout_seconds": {
+                "title": "Timeout Seconds",
+                "description": "The number of seconds to wait for the job run before timing out.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "v1_job",
+              "credentials"
+            ],
+            "block_type_slug": "k8s-job",
+            "secret_fields": [],
+            "block_schema_references": {
+              "credentials": {
+                "block_type_slug": "kubernetes-credentials",
+                "block_schema_checksum": "sha256:957fa8dca90bd1b5fb9c575ee09e80b454116c0b134287fbc2eff47a72564c3b"
+              }
+            }
+          }
+        }
+      },
+      "path_containing_flow": "prefect_kubernetes/flows.py",
+      "repo_url": "https://github.com/PrefectHQ/prefect-kubernetes",
+      "slug": "run_namespaced_job"
+    }
+  }
+}

--- a/src/update_collection_metadata.py
+++ b/src/update_collection_metadata.py
@@ -191,11 +191,3 @@ async def update_all_collections(
         return Failed(message=f"Some subflows failed: {listrepr(failed_subflow_runs)} ")
 
     return Completed(message="All new releases have been recorded.")
-
-
-if __name__ == "__main__":
-    for collection_name in utils.get_collection_names():
-        update_collection_metadata(
-            collection_name=collection_name,
-            branch_name="improve-docstring-parsing",
-        )

--- a/src/update_collection_metadata.py
+++ b/src/update_collection_metadata.py
@@ -191,3 +191,11 @@ async def update_all_collections(
         return Failed(message=f"Some subflows failed: {listrepr(failed_subflow_runs)} ")
 
     return Completed(message="All new releases have been recorded.")
+
+
+if __name__ == "__main__":
+    for collection_name in utils.get_collection_names():
+        update_collection_metadata(
+            collection_name=collection_name,
+            branch_name="improve-docstring-parsing",
+        )

--- a/src/utils.py
+++ b/src/utils.py
@@ -155,7 +155,7 @@ def submit_updates(
             print(
                 f"{variety} metadata for {collection_name} {latest_release} already exists!"
             )
-            return
+            # return
         else:
             raise
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -155,7 +155,7 @@ def submit_updates(
             print(
                 f"{variety} metadata for {collection_name} {latest_release} already exists!"
             )
-            # return
+            return
         else:
             raise
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,13 +17,6 @@ from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.importtools import load_module, to_qualified_name
 from typing_extensions import Literal
 
-exclude_collections = {
-    f"https://prefecthq.github.io/{collection}/"
-    for collection in [
-        "prefect-ray",
-    ]
-}
-
 CollectionViewVariety = Literal["block", "flow", "worker"]
 
 
@@ -189,11 +182,10 @@ def get_collection_names():
     repo_name = "prefect-collection-registry"
     path = "collections"
 
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents/{path}"
-
-    headers = {"Accept": "application/vnd.github+json"}
-
-    response = httpx.get(url, headers=headers)
+    response = httpx.get(
+        url=f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents/{path}",
+        headers={"Accept": "application/vnd.github+json"},
+    )
 
     return [item["name"] for item in response.json() if item["type"] == "dir"]
 

--- a/views/aggregate-block-metadata.json
+++ b/views/aggregate-block-metadata.json
@@ -3299,6 +3299,9 @@
       }
     }
   },
+  "prefect-dask": {
+    "block_types": {}
+  },
   "prefect-databricks": {
     "block_types": {
       "databricks-credentials": {

--- a/views/aggregate-flow-metadata.json
+++ b/views/aggregate-flow-metadata.json
@@ -148,7 +148,8 @@
     "run_census_sync": {
       "description": {
         "summary": "A flow for triggering a Census sync run and waiting for completion.",
-        "returns": "The result of the sync run."
+        "returns": "The result of the sync run.",
+        "examples": []
       },
       "documentation_url": "https://prefecthq.github.io/prefect-census/flows/#prefect_census.flows.run_census_sync",
       "entrypoint": "prefect_census/flows.py:run_census_sync",
@@ -257,7 +258,8 @@
     },
     "wait_census_sync_completion": {
       "description": {
-        "summary": "Waits for the Census sync run to finish running."
+        "summary": "Waits for the Census sync run to finish running.",
+        "examples": []
       },
       "documentation_url": "https://prefecthq.github.io/prefect-census/runs/#prefect_census.runs.wait_census_sync_completion",
       "entrypoint": "prefect_census/runs.py:wait_census_sync_completion",
@@ -334,7 +336,10 @@
     },
     "trigger_census_sync_run_and_wait_for_completion": {
       "description": {
-        "summary": "Triggers a Census sync run and waits for thetriggered run to complete."
+        "summary": "Triggers a Census sync run and waits for thetriggered run to complete.",
+        "examples": [
+          "Trigger a Census sync using CensusCredentials instance and wait\nfor completion as a standalone flow:\n```python\nimport asyncio\n\nfrom prefect_census import CensusCredentials\nfrom prefect_census.syncs import trigger_census_sync_run_and_wait_for_completion\n\nasyncio.run(\n    trigger_census_sync_run_and_wait_for_completion(\n        credentials=CensusCredentials(\n            api_key=\"my_api_key\"\n        ),\n        sync_id=42\n    )\n)\n```\n\nTrigger a Census sync and wait for completion as a subflow:\n```python\nfrom prefect import flow\n\nfrom prefect_census import CensusCredentials\nfrom prefect_census.syncs import trigger_census_sync_run_and_wait_for_completion\n\n@flow\ndef my_flow():\n    ...\n    creds = CensusCredentials(api_key=\"my_api_key\")\n    run_result = trigger_census_sync_run_and_wait_for_completion(\n        credentials=creds,\n        sync_id=42\n    )\n    ...\n\nmy_flow()\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-census/syncs/#prefect_census.syncs.trigger_census_sync_run_and_wait_for_completion",
       "entrypoint": "prefect_census/syncs.py:trigger_census_sync_run_and_wait_for_completion",
@@ -420,7 +425,10 @@
   "prefect-databricks": {
     "jobs_runs_submit_and_wait_for_completion": {
       "description": {
-        "summary": "Triggers a Databricks jobs runs and waits for the triggered runs to complete."
+        "summary": "Triggers a Databricks jobs runs and waits for the triggered runs to complete.",
+        "examples": [
+          "Submit jobs runs and wait.\n```python\nfrom prefect import flow\nfrom prefect_databricks import DatabricksCredentials\nfrom prefect_databricks.flows import jobs_runs_submit_and_wait_for_completion\nfrom prefect_databricks.models.jobs import (\n    AutoScale,\n    AwsAttributes,\n    JobTaskSettings,\n    NotebookTask,\n    NewCluster,\n)\n\n@flow\ndef jobs_runs_submit_and_wait_for_completion_flow(notebook_path, **base_parameters):\n    databricks_credentials = await DatabricksCredentials.load(\"BLOCK_NAME\")\n\n    # specify new cluster settings\n    aws_attributes = AwsAttributes(\n        availability=\"SPOT\",\n        zone_id=\"us-west-2a\",\n        ebs_volume_type=\"GENERAL_PURPOSE_SSD\",\n        ebs_volume_count=3,\n        ebs_volume_size=100,\n    )\n    auto_scale = AutoScale(min_workers=1, max_workers=2)\n    new_cluster = NewCluster(\n        aws_attributes=aws_attributes,\n        autoscale=auto_scale,\n        node_type_id=\"m4.large\",\n        spark_version=\"10.4.x-scala2.12\",\n        spark_conf={\"spark.speculation\": True},\n    )\n\n    # specify notebook to use and parameters to pass\n    notebook_task = NotebookTask(\n        notebook_path=notebook_path,\n        base_parameters=base_parameters,\n    )\n\n    # compile job task settings\n    job_task_settings = JobTaskSettings(\n        new_cluster=new_cluster,\n        notebook_task=notebook_task,\n        task_key=\"prefect-task\"\n    )\n\n    multi_task_runs = jobs_runs_submit_and_wait_for_completion(\n        databricks_credentials=databricks_credentials,\n        run_name=\"prefect-job\",\n        tasks=[job_task_settings]\n    )\n\n    return multi_task_runs\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-databricks/flows/#prefect_databricks.flows.jobs_runs_submit_and_wait_for_completion",
       "entrypoint": "prefect_databricks/flows.py:jobs_runs_submit_and_wait_for_completion",
@@ -1645,7 +1653,10 @@
     },
     "jobs_runs_wait_for_completion": {
       "description": {
-        "summary": "Waits for the jobs runs to finish running"
+        "summary": "Waits for the jobs runs to finish running",
+        "examples": [
+          "Waits for completion on jobs runs.\n```python\nfrom prefect import flow\nfrom prefect_databricks import DatabricksCredentials\nfrom prefect_databricks.flows import jobs_runs_wait_for_completion\n\n@flow\ndef jobs_runs_wait_for_completion_flow():\n    databricks_credentials = DatabricksCredentials.load(\"BLOCK_NAME\")\n    return jobs_runs_wait_for_completion(\n        multi_task_jobs_run_id=45429,\n        databricks_credentials=databricks_credentials,\n        run_name=\"my_run_name\",\n        max_wait_seconds=1800,  # 30 minutes\n        poll_frequency_seconds=120,  # 2 minutes\n    )\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-databricks/flows/#prefect_databricks.flows.jobs_runs_wait_for_completion",
       "entrypoint": "prefect_databricks/flows.py:jobs_runs_wait_for_completion",
@@ -1740,7 +1751,10 @@
   "prefect-dbt": {
     "retry_dbt_cloud_job_run_subset_and_wait_for_completion": {
       "description": {
-        "summary": "Retries a subset of dbt Cloud job run, filtered by select statuses, and waits for the triggered retry to complete."
+        "summary": "Retries a subset of dbt Cloud job run, filtered by select statuses, and waits for the triggered retry to complete.",
+        "examples": [
+          "Retry a subset of models in a dbt Cloud job run and wait for completion:\n```python\nfrom prefect import flow\n\nfrom prefect_dbt.cloud import DbtCloudCredentials\nfrom prefect_dbt.cloud.jobs import retry_dbt_cloud_job_run_subset_and_wait_for_completion\n\n@flow\ndef retry_dbt_cloud_job_run_subset_and_wait_for_completion_flow():\n    credentials = DbtCloudCredentials.load(\"MY_BLOCK_NAME\")\n    retry_dbt_cloud_job_run_subset_and_wait_for_completion(\n        dbt_cloud_credentials=credentials,\n        run_id=88640123,\n    )\n\nretry_dbt_cloud_job_run_subset_and_wait_for_completion_flow()\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-dbt/cloud/jobs/#prefect_dbt.cloud.jobs.retry_dbt_cloud_job_run_subset_and_wait_for_completion",
       "entrypoint": "prefect_dbt/cloud/jobs.py:retry_dbt_cloud_job_run_subset_and_wait_for_completion",
@@ -1899,7 +1913,10 @@
     },
     "run_dbt_cloud_job": {
       "description": {
-        "summary": "Flow that triggers and waits for a dbt Cloud job run, retrying a\nsubset of failed nodes if necessary."
+        "summary": "Flow that triggers and waits for a dbt Cloud job run, retrying a\nsubset of failed nodes if necessary.",
+        "examples": [
+          "```python\nfrom prefect import flow\nfrom prefect_dbt.cloud import DbtCloudCredentials, DbtCloudJob\nfrom prefect_dbt.cloud.jobs import run_dbt_cloud_job\n\n@flow\ndef run_dbt_cloud_job_flow():\n    dbt_cloud_credentials = DbtCloudCredentials.load(\"dbt-token\")\n    dbt_cloud_job = DbtCloudJob(\n        dbt_cloud_credentials=dbt_cloud_credentials, job_id=154217\n    )\n    return run_dbt_cloud_job(dbt_cloud_job=dbt_cloud_job)\n\nrun_dbt_cloud_job_flow()\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-dbt/cloud/jobs/#prefect_dbt.cloud.jobs.run_dbt_cloud_job",
       "entrypoint": "prefect_dbt/cloud/jobs.py:run_dbt_cloud_job",
@@ -2090,7 +2107,10 @@
     },
     "trigger_dbt_cloud_job_run_and_wait_for_completion": {
       "description": {
-        "summary": "Triggers a dbt Cloud job run and waits for thetriggered run to complete."
+        "summary": "Triggers a dbt Cloud job run and waits for thetriggered run to complete.",
+        "examples": [
+          "Trigger a dbt Cloud job and wait for completion as a stand alone flow:\n```python\nimport asyncio\nfrom prefect_dbt.cloud import DbtCloudCredentials\nfrom prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run_and_wait_for_completion\n\nasyncio.run(\n    trigger_dbt_cloud_job_run_and_wait_for_completion(\n        dbt_cloud_credentials=DbtCloudCredentials(\n            api_key=\"my_api_key\",\n            account_id=123456789\n        ),\n        job_id=1\n    )\n)\n```\n\nTrigger a dbt Cloud job and wait for completion as a sub-flow:\n```python\nfrom prefect import flow\nfrom prefect_dbt.cloud import DbtCloudCredentials\nfrom prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run_and_wait_for_completion\n\n@flow\ndef my_flow():\n    ...\n    run_result = trigger_dbt_cloud_job_run_and_wait_for_completion(\n        dbt_cloud_credentials=DbtCloudCredentials(\n            api_key=\"my_api_key\",\n            account_id=123456789\n        ),\n        job_id=1\n    )\n    ...\n\nmy_flow()\n```\n\nTrigger a dbt Cloud job with overrides:\n```python\nimport asyncio\nfrom prefect_dbt.cloud import DbtCloudCredentials\nfrom prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run_and_wait_for_completion\nfrom prefect_dbt.cloud.models import TriggerJobRunOptions\n\nasyncio.run(\n    trigger_dbt_cloud_job_run_and_wait_for_completion(\n        dbt_cloud_credentials=DbtCloudCredentials(\n            api_key=\"my_api_key\",\n            account_id=123456789\n        ),\n        job_id=1,\n        trigger_job_run_options=TriggerJobRunOptions(\n            git_branch=\"staging\",\n            schema_override=\"dbt_cloud_pr_123\",\n            dbt_version_override=\"0.18.0\",\n            target_name_override=\"staging\",\n            timeout_seconds_override=3000,\n            generate_docs_override=True,\n            threads_override=8,\n            steps_override=[\n                \"dbt seed\",\n                \"dbt run --fail-fast\",\n                \"dbt test --fail fast\",\n            ],\n        ),\n    )\n)\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-dbt/cloud/jobs/#prefect_dbt.cloud.jobs.trigger_dbt_cloud_job_run_and_wait_for_completion",
       "entrypoint": "prefect_dbt/cloud/jobs.py:trigger_dbt_cloud_job_run_and_wait_for_completion",
@@ -2256,7 +2276,8 @@
     },
     "wait_for_dbt_cloud_job_run": {
       "description": {
-        "summary": "Waits for a dbt Cloud job run to finish running."
+        "summary": "Waits for a dbt Cloud job run to finish running.",
+        "examples": []
       },
       "documentation_url": "https://prefecthq.github.io/prefect-dbt/cloud/runs/#prefect_dbt.cloud.runs.wait_for_dbt_cloud_job_run",
       "entrypoint": "prefect_dbt/cloud/runs.py:wait_for_dbt_cloud_job_run",
@@ -2348,7 +2369,10 @@
     "trigger_project_run_and_wait_for_completion": {
       "description": {
         "summary": "Flow that triggers a project run and waits for the triggered run to complete.",
-        "returns": "Information about the triggered project run."
+        "returns": "Information about the triggered project run.",
+        "examples": [
+          "Trigger a Hex project run and wait for completion as a stand-alone flow.\n```python\nimport asyncio\nfrom prefect_hex import HexCredentials\nfrom prefect_hex.project import trigger_project_run_and_wait_for_completion\n\nasyncio.run(\n    trigger_sync_run_and_wait_for_completion(\n        hex_credentials=HexCredentials(\n            token=\"1abc0d23-1234-1a2b-abc3-12ab456c7d8e\"\n        ),\n        project_id=\"012345c6-b67c-1234-1b2c-66e4ad07b9f3\",\n        max_wait_seconds=1800,\n        poll_frequency_seconds=5,\n    )\n)\n```\n\nTrigger a Hex project run and wait for completion as a subflow.\n```python\nfrom prefect import flow\nfrom prefect_hex import HexCredentials\nfrom prefect_hex.project import trigger_project_run_and_wait_for_completion\n\n@flow\ndef trigger_project_run_and_wait_for_completion_flow(project_id: str):\n    hex_credentials = HexCredentials.load(\"hex-token\")\n    project_metadata = trigger_project_run_and_wait_for_completion(\n        project_id=project_id,\n        hex_credentials=hex_credentials\n    )\n    return project_metadata\n\ntrigger_project_run_and_wait_for_completion_flow(\n    project_id=\"012345c6-b67c-1234-1b2c-66e4ad07b9f3\"\n)\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-hex/project/#prefect_hex.project.trigger_project_run_and_wait_for_completion",
       "entrypoint": "prefect_hex/project.py:trigger_project_run_and_wait_for_completion",
@@ -2445,7 +2469,10 @@
     "wait_for_project_run_completion": {
       "description": {
         "summary": "Flow that waits for the triggered project run to complete.",
-        "returns": "The status of the project run and the metadata associated with the run."
+        "returns": "The status of the project run and the metadata associated with the run.",
+        "examples": [
+          "Wait for completion of a project run as a subflow.\n```python\nfrom prefect import flow\nfrom prefect_hex import HexCredentials\nfrom prefect_hex.project import wait_for_project_run_completion\n\n@flow\ndef wait_for_project_run_completion_flow(project_id: str, run_id: str):\n    hex_credentials = HexCredentials.load(\"hex-token\")\n    project_status, project_metadata = wait_for_project_run_completion(\n        project_id=project_id,\n        run_id=run_id,\n        hex_credentials=hex_credentials\n    )\n    return project_status, project_metadata\n\nwait_for_project_run_completion_flow(\n    project_id=\"012345c6-b67c-1234-1b2c-66e4ad07b9f3\",\n    run_id=\"654321c6-b67c-1234-1b2c-66e4ad07b9f3\",\n)\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-hex/project/#prefect_hex.project.wait_for_project_run_completion",
       "entrypoint": "prefect_hex/project.py:wait_for_project_run_completion",
@@ -2538,7 +2565,10 @@
     "trigger_sync_run_and_wait_for_completion": {
       "description": {
         "summary": "Flow that triggers a sync run and waits for the triggered run to complete.",
-        "returns": "- `id`: `str`<br>\n- `slug`: `str`<br>\n- `workspace_id`: `str`<br>\n- `created_at`: `str`<br>\n- `updated_at`: `str`<br>\n- `destination_id`: `str`<br>\n- `model_id`: `str`<br>\n- `configuration`: `Dict`<br>\n- `schedule`: `Dict`<br>\n- `status`: `\"models.SyncStatus\"`<br>\n- `disabled`: `bool`<br>\n- `last_run_at`: `str`<br>\n- `referenced_columns`: `List[str]`<br>\n- `primary_key`: `str`<br>"
+        "returns": "- `id`: `str`<br>\n- `slug`: `str`<br>\n- `workspace_id`: `str`<br>\n- `created_at`: `str`<br>\n- `updated_at`: `str`<br>\n- `destination_id`: `str`<br>\n- `model_id`: `str`<br>\n- `configuration`: `Dict`<br>\n- `schedule`: `Dict`<br>\n- `status`: `\"models.SyncStatus\"`<br>\n- `disabled`: `bool`<br>\n- `last_run_at`: `str`<br>\n- `referenced_columns`: `List[str]`<br>\n- `primary_key`: `str`<br>",
+        "examples": [
+          "Trigger a Hightouch sync run and wait for completion as a stand alone flow.\n```python\nimport asyncio\n\nfrom prefect_hightouch import HightouchCredentials\nfrom prefect_hightouch.syncs import trigger_sync_run_and_wait_for_completion\n\nasyncio.run(\n    trigger_sync_run_and_wait_for_completion(\n        hightouch_credentials=HightouchCredentials(\n            token=\"1abc0d23-1234-1a2b-abc3-12ab456c7d8e\"\n        ),\n        sync_id=12345,\n        full_resync=True,\n        max_wait_seconds=1800,\n        poll_frequency_seconds=5,\n    )\n)\n```\n\nTrigger a Hightouch sync run and wait for completion as a subflow.\n```python\nfrom prefect import flow\n\nfrom prefect_hightouch import HightouchCredentials\nfrom prefect_hightouch.syncs import trigger_sync_run_and_wait_for_completion\n\n@flow\ndef sync_flow():\n    hightouch_credentials = HightouchCredentials.load(\"hightouch-token\")\n    sync_metadata = trigger_sync_run_and_wait_for_completion(\n        hightouch_credentials=hightouch_credentials,\n        sync_id=12345,\n        full_resync=True,\n        max_wait_seconds=1800,\n        poll_frequency_seconds=10,\n    )\n    return sync_metadata\n\nsync_flow()\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-hightouch/syncs/flows/#prefect_hightouch.syncs.flows.trigger_sync_run_and_wait_for_completion",
       "entrypoint": "prefect_hightouch/syncs/flows.py:trigger_sync_run_and_wait_for_completion",
@@ -2634,7 +2664,10 @@
     "wait_for_sync_run_completion": {
       "description": {
         "summary": "Flow that waits for the triggered sync run to complete.",
-        "returns": "- `value`\n- `id`: `str`<br>\n- `slug`: `str`<br>\n- `workspace_id`: `str`<br>\n- `created_at`: `str`<br>\n- `updated_at`: `str`<br>\n- `destination_id`: `str`<br>\n- `model_id`: `str`<br>\n- `configuration`: `Dict`<br>\n- `schedule`: `Dict`<br>\n- `status`: `\"api_models.SyncStatus\"`<br>\n- `disabled`: `bool`<br>\n- `last_run_at`: `str`<br>\n- `referenced_columns`: `List[str]`<br>\n- `primary_key`: `str`<br>"
+        "returns": "- `value`\n- `id`: `str`<br>\n- `slug`: `str`<br>\n- `workspace_id`: `str`<br>\n- `created_at`: `str`<br>\n- `updated_at`: `str`<br>\n- `destination_id`: `str`<br>\n- `model_id`: `str`<br>\n- `configuration`: `Dict`<br>\n- `schedule`: `Dict`<br>\n- `status`: `\"api_models.SyncStatus\"`<br>\n- `disabled`: `bool`<br>\n- `last_run_at`: `str`<br>\n- `referenced_columns`: `List[str]`<br>\n- `primary_key`: `str`<br>",
+        "examples": [
+          "Wait for completion as a subflow.\n```python\nfrom prefect import flow\n\nfrom prefect_hightouch import HightouchCredentials\nfrom prefect_hightouch.syncs import wait_for_sync_run_completion\n\n@flow\ndef wait_flow():\n    hightouch_credentials = HightouchCredentials.load(\"hightouch-token\")\n    sync_status, sync_metadata = wait_for_sync_run_completion(\n        hightouch_credentials=hightouch_credentials,\n        sync_id=12345,\n        max_wait_seconds=1800,\n        poll_frequency_seconds=20,\n    )\n    return sync_metadata\n\nwait_flow()\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-hightouch/syncs/flows/#prefect_hightouch.syncs.flows.wait_for_sync_run_completion",
       "entrypoint": "prefect_hightouch/syncs/flows.py:wait_for_sync_run_completion",
@@ -2870,7 +2903,10 @@
   "prefect-monte-carlo": {
     "create_or_update_lineage": {
       "description": {
-        "summary": "Create or update a `source` node, `destination` node, and the edge that connects them."
+        "summary": "Create or update a `source` node, `destination` node, and the edge that connects them.",
+        "examples": [
+          "Create or update a lineage edge between a source and destination node.\n```python\nfrom prefect import flow\nfrom prefect.context import get_run_context\nfrom prefect_monte_carlo.credentials import MonteCarloCredentials\nfrom prefect_monte_carlo.lineage import (\n    create_or_update_lineage, MonteCarloLineageNode\n)\n\n@flow\ndef monte_carlo_orchestrator():\n    flow_run_name = get_run_context().flow_run.name\n\n    source = MonteCarloLineageNode(\n        node_name=\"source_dataset\",\n        object_id=\"source_dataset\",\n        object_type=\"table\",\n        resource_name=\"some_resource_name\",\n        tags=[{\"propertyName\": \"dataset_owner\", \"propertyValue\": \"owner_name\"}],\n    )\n\n    destination = MonteCarloLineageNode(\n        node_name=\"destination_dataset\",\n        object_id=\"destination_dataset\",\n        object_type=\"table\",\n        resource_name=\"some_resource_name\",\n        tags=[{\"propertyName\": \"dataset_owner\", \"propertyValue\": \"owner_name\"}],\n    )\n\n    # `create_or_update_lineage` is a flow, so this will be a subflow run\n    # `extra_tags` are added to both the `source` and `destination` nodes\n    create_or_update_lineage(\n        monte_carlo_credentials=MonteCarloCredentials.load(\"my-mc-creds)\n        source=source,\n        destination=destination,\n        expire_at=datetime.now() + timedelta(days=10),\n        extra_tags=[\n            {\"propertyName\": \"flow_run_name\", \"propertyValue\": flow_run_name}\n        ]\n    )\n\n```"
+        ]
       },
       "documentation_url": "https://prefecthq.github.io/prefect-monte-carlo/lineage/#prefect_monte_carlo.lineage.create_or_update_lineage",
       "entrypoint": "prefect_monte_carlo/lineage.py:create_or_update_lineage",


### PR DESCRIPTION
changes parsing of the examples section of the docstring to capture both `Examples:` and `Example` style examples in docstrings to address the point raised by @sarahmk125 in #187 

and updates the aggregate flow view according to this change

checking with @zhen0 that the UI can still render the examples (in this new format) as expected