### PR TITLE
Update worker metadata format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,4 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["pytest", "coverage"]
+dev = ["pytest", "coverage", "prefect-kubernetes"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 coverage
+prefect-kubernetes

--- a/src/generate_worker_metadata.py
+++ b/src/generate_worker_metadata.py
@@ -30,7 +30,9 @@ def generate_worker_metadata(worker_subcls: Type[BaseWorker], package_name: str)
                 "description": worker_subcls.get_description(),
                 "logo_url": worker_subcls.get_logo_url(),
                 "documentation_url": worker_subcls.get_documentation_url(),
-                "default_base_job_configuration": worker_subcls.get_default_base_job_template(),  # noqa E501
+                "default_base_job_configuration": (
+                    worker_subcls.get_default_base_job_template()
+                ),  # noqa E501
             }.items()
         )
     )
@@ -76,7 +78,7 @@ def get_worker_metadata_from_collection(collection_name: str):
     """Gets worker metadata from a given collection."""
     collections = safe_load_entrypoints(entry_points(group="prefect.collections"))
 
-    output = {"workers": {}}
+    output = {}
     for ep_name, module in collections.items():
         if isinstance(module, Exception):
             logging.warning(f"Error loading collection entrypoint {ep_name} - skipping")
@@ -87,13 +89,11 @@ def get_worker_metadata_from_collection(collection_name: str):
 
         worker_subclasses = discover_base_worker_subclasses(module)
         for worker_subcls in worker_subclasses:
-            output["workers"].update(
-                generate_worker_metadata(
-                    worker_subcls=worker_subcls, package_name=collection_name
-                )
+            output[worker_subcls.type] = generate_worker_metadata(
+                worker_subcls=worker_subcls, package_name=collection_name
             )
 
-    output["workers"] = dict(sorted(output["workers"].items()))
+    output = dict(sorted(output.items()))
     return output
 
 

--- a/tests/test_generate_worker_metadata.py
+++ b/tests/test_generate_worker_metadata.py
@@ -1,0 +1,23 @@
+import fastjsonschema
+from generate_worker_metadata import generate_worker_metadata_for_package
+from metadata_schemas import worker_schema
+import pytest
+
+
+@pytest.mark.parametrize(
+    "package_name,expected_worker_types",
+    [
+        ("prefect", {"prefect-agent", "process"}),
+        ("prefect-kubernetes", {"kubernetes"}),
+    ],
+)
+def test_generate_worker_metadata_for_package(package_name, expected_worker_types):
+    """Tests that worker metadata is generated correctly."""
+    # prefect-kubernetes is a dev dependency
+    result = generate_worker_metadata_for_package(package_name)
+    assert set(result.keys()) == expected_worker_types
+
+    validate = fastjsonschema.compile(worker_schema)
+    for worker_metadata in result.values():
+        # will raise if metadata is invalid
+        validate(worker_metadata)


### PR DESCRIPTION
### Description

Consumers of the the worker metadata are expecting specific worker metadata to be nested under their type name. This PR updates the worker generation script to use the type name of each worker instead of `worker` for the nested key. This is also important to handle packages that have multiple workers.

### Example:
`prefect-aws` changes from:

```json
{
   "workers":{
      "default_base_job_configuration":{
          ...
      },
      "description":"",
      "documentation_url":"",
      "install_command":"pip install prefect-aws",
      "logo_url":"",
      "type":"ecs"
   }
}
```

to

```json
{
   "ecs":{
      "default_base_job_configuration":{
            ...
      },
      "description":"",
      "documentation_url":"",
      "install_command":"pip install prefect-aws",
      "logo_url":"",
      "type":"ecs"
   }
}
```