### PR TITLE
Update blocks blacklist to include `custom-webhook`

### DIFF
--- a/src/generate_block_metadata.py
+++ b/src/generate_block_metadata.py
@@ -19,7 +19,7 @@ from metadata_schemas import block_schema
 
 # Some collection blocks share names with core blocks. We exclude them
 # from the registry for now to avoid confusion.
-BLOCKS_BLACKLIST = {"k8s-job"}
+BLOCKS_BLACKLIST = {"k8s-job", "custom-webhook"}
 
 
 def generate_block_metadata(block_subcls: Type[Block]) -> Dict[str, Any]:


### PR DESCRIPTION
Updates `BLOCKS_BLACKLIST` to ignore `custom-webhook` introduced in https://github.com/PrefectHQ/prefect/pull/9547 to prevent conflict and confusion with the `webhook` block in Cloud.