### PR TITLE
Fix worker metadata

### DIFF
--- a/src/generate_worker_metadata.py
+++ b/src/generate_worker_metadata.py
@@ -30,14 +30,14 @@ def generate_worker_metadata(worker_subcls: Type[BaseWorker], package_name: str)
                 "install_command": f"pip install {package_name}",
                 "description": worker_subcls.get_description(),
                 "display_name": getattr(
-                    worker_subcls, "display_name", worker_subcls.type
+                    worker_subcls, "_display_name", worker_subcls.type
                 ),
                 "logo_url": worker_subcls.get_logo_url(),
                 "documentation_url": worker_subcls.get_documentation_url(),
                 "default_base_job_configuration": (
                     worker_subcls.get_default_base_job_template()
                 ),  # noqa E501
-                "is_beta": getattr(worker_subcls, "is_beta", False),
+                "is_beta": getattr(worker_subcls, "_is_beta", False),
             }.items()
         )
     )

--- a/views/aggregate-worker-metadata.json
+++ b/views/aggregate-worker-metadata.json
@@ -67,7 +67,7 @@
       "display_name": "Local Subprocess",
       "documentation_url": "https://docs.prefect.io/latest/api-ref/prefect/workers/process/",
       "install_command": "pip install prefect",
-      "is_beta": false,
+      "is_beta": true,
       "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/39WQhVu4JK40rZWltGqhuC/d15be6189a0cb95949a6b43df00dcb9b/image5.png?h=250",
       "type": "process"
     }
@@ -365,7 +365,7 @@
       "display_name": "AWS Elastic Container Service",
       "documentation_url": "https://prefecthq.github.io/prefect-aws/ecs_worker/",
       "install_command": "pip install prefect-aws",
-      "is_beta": false,
+      "is_beta": true,
       "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/1jbV4lceHOjGgunX15lUwT/db88e184d727f721575aeb054a37e277/aws.png?h=250",
       "type": "ecs"
     }
@@ -995,7 +995,7 @@
       "display_name": "Google Cloud Run",
       "documentation_url": "https://prefecthq.github.io/prefect-gcp/worker/",
       "install_command": "pip install prefect-gcp",
-      "is_beta": false,
+      "is_beta": true,
       "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/4SpnOBvMYkHp6z939MDKP6/549a91bc1ce9afd4fb12c68db7b68106/social-icon-google-cloud-1200-630.png?h=250",
       "type": "cloud-run"
     }
@@ -1165,7 +1165,7 @@
       "display_name": "Kubernetes",
       "documentation_url": "https://prefecthq.github.io/prefect-kubernetes/worker/",
       "install_command": "pip install prefect-kubernetes",
-      "is_beta": false,
+      "is_beta": true,
       "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/1zrSeY8DZ1MJZs2BAyyyGk/20445025358491b8b72600b8f996125b/Kubernetes_logo_without_workmark.svg.png?h=250",
       "type": "kubernetes"
     }

--- a/views/aggregate-worker-metadata.json
+++ b/views/aggregate-worker-metadata.json
@@ -63,9 +63,9 @@
           }
         }
       },
-      "description": "Worker that executes flow runs within processes.",
-      "display_name": "process",
-      "documentation_url": "",
+      "description": "Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.",
+      "display_name": "Local Subprocess",
+      "documentation_url": "https://docs.prefect.io/latest/api-ref/prefect/workers/process/",
       "install_command": "pip install prefect",
       "is_beta": false,
       "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/39WQhVu4JK40rZWltGqhuC/d15be6189a0cb95949a6b43df00dcb9b/image5.png?h=250",
@@ -362,7 +362,7 @@
         }
       },
       "description": "Execute flow runs within containers on AWS ECS. Works with existing ECS clusters and serverless execution via AWS Fargate. Requires an AWS account.",
-      "display_name": "ecs",
+      "display_name": "AWS Elastic Container Service",
       "documentation_url": "https://prefecthq.github.io/prefect-aws/ecs_worker/",
       "install_command": "pip install prefect-aws",
       "is_beta": false,
@@ -992,7 +992,7 @@
         }
       },
       "description": "Execute flow runs within containers on Google Cloud Run. Requires a Google Cloud Platform account.",
-      "display_name": "cloud-run",
+      "display_name": "Google Cloud Run",
       "documentation_url": "https://prefecthq.github.io/prefect-gcp/worker/",
       "install_command": "pip install prefect-gcp",
       "is_beta": false,
@@ -1162,7 +1162,7 @@
         }
       },
       "description": "Execute flow runs within jobs scheduled on a Kubernetes cluster. Requires a Kubernetes cluster.",
-      "display_name": "kubernetes",
+      "display_name": "Kubernetes",
       "documentation_url": "https://prefecthq.github.io/prefect-kubernetes/worker/",
       "install_command": "pip install prefect-kubernetes",
       "is_beta": false,


### PR DESCRIPTION
Some worker metadata wasn't generated correctly in the last run. This reverts a couple of the changes from the last run. Also fixes the source of the incorrectly generated config.