### PR TITLE
Adds missing variables to ACI worker base job template

### DIFF
--- a/views/aggregate-worker-metadata.json
+++ b/views/aggregate-worker-metadata.json
@@ -545,6 +545,18 @@
               "default": 1.0,
               "type": "number"
             },
+            "subnet_ids": {
+              "title": "Subnet IDs",
+              "description": "A list of Azure subnet IDs to use for the ACI task.",
+              "type": "array",
+              "items": {"type": "string"}
+            },
+            "dns_servers": {
+              "title": "DNS Servers",
+              "description": "A list of DNS servers to use for the ACI task.",
+              "type": "array",
+              "items": {"type": "string"}
+            },
             "aci_credentials": {
               "title": "Aci Credentials",
               "description": "The credentials to use to authenticate with Azure.",


### PR DESCRIPTION
A fix to base job template validation in https://github.com/PrefectHQ/prefect/pull/10385 causes the default base job template for the ACI worker to fail validation. This would prevent any ACI work pools from being created. This is hot fix for the template to avoid user errors. The long term fix is in `prefect-azure` with https://github.com/PrefectHQ/prefect-azure/pull/113.