### PR TITLE
Adds `slack-incoming-webhook` to blocked blocks

### DIFF
--- a/src/generate_block_metadata.py
+++ b/src/generate_block_metadata.py
@@ -19,7 +19,7 @@ from metadata_schemas import block_schema
 
 # Some collection blocks share names with core blocks. We exclude them
 # from the registry for now to avoid confusion.
-BLOCKS_BLOCKLIST = {"k8s-job", "custom-webhook"}
+BLOCKS_BLOCKLIST = {"k8s-job", "custom-webhook", "slack-incoming-webhook"}
 
 
 def generate_block_metadata(block_subcls: Type[Block]) -> Dict[str, Any]:

--- a/views/aggregate-block-metadata.json
+++ b/views/aggregate-block-metadata.json
@@ -8015,44 +8015,6 @@
           "capabilities": [],
           "version": "0.1.2"
         }
-      },
-      "slack-incoming-webhook": {
-        "name": "Slack Incoming Webhook",
-        "slug": "slack-incoming-webhook",
-        "logo_url": "https://cdn.sanity.io/images/3ugk85nk/production/c1965ecbf8704ee1ea20d77786de9a41ce1087d1-500x500.png",
-        "documentation_url": "https://prefecthq.github.io/prefect-slack/credentials/#prefect_slack.credentials.SlackWebhook",
-        "description": "Block holding a Slack webhook for use in tasks and flows. This block is part of the prefect-slack collection. Install prefect-slack with `pip install prefect-slack` to use this block.",
-        "code_example": "Load stored Slack webhook:\n```python\nfrom prefect_slack import SlackWebhook\nslack_webhook_block = SlackWebhook.load(\"BLOCK_NAME\")\n```",
-        "block_schema": {
-          "checksum": "sha256:7e03b5158eed175ba9ae53275933944c9f9161b7b45748878701716857656a4a",
-          "fields": {
-            "title": "SlackWebhook",
-            "description": "Block holding a Slack webhook for use in tasks and flows.",
-            "type": "object",
-            "properties": {
-              "url": {
-                "title": "Webhook URL",
-                "description": "Slack webhook URL which can be used to send messages.",
-                "example": "https://hooks.slack.com/XXX",
-                "type": "string",
-                "writeOnly": true,
-                "format": "password"
-              }
-            },
-            "required": [
-              "url"
-            ],
-            "block_type_slug": "slack-incoming-webhook",
-            "secret_fields": [
-              "url"
-            ],
-            "block_schema_references": {}
-          },
-          "capabilities": [
-            "notify"
-          ],
-          "version": "0.1.2"
-        }
       }
     }
   },


### PR DESCRIPTION
Block `SlackWebhook` block from `prefect-slack` from being registered to prevent user confusion.