### PR TITLE
fix worker metadata generation for prefect core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - fix-ci
     paths:
       - 'src/**'
       - 'tests/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,12 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - fix-ci
   pull_request:
     branches:
       - main
-      - fix-ci
     paths:
       - 'src/**'
       - 'tests/**'

--- a/src/generate_worker_metadata.py
+++ b/src/generate_worker_metadata.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Type
 
 import fastjsonschema
 from prefect import flow, task
+from prefect.logging.loggers import get_logger
 from prefect.plugins import safe_load_entrypoints
 from prefect.utilities.dispatch import get_registry_for_type
 from prefect.utilities.importtools import to_qualified_name
@@ -23,6 +24,7 @@ import utils
 # See https://github.com/PrefectHQ/prefect/pull/11180 for more details
 WORKERS_BLOCKLIST = {"BaseWorker", "BlockWorker"}
 
+logger = get_logger("generate_worker_metadata")
 
 @task
 def generate_worker_metadata(worker_subcls: Type[BaseWorker], package_name: str):
@@ -104,6 +106,7 @@ def get_worker_metadata_from_collection(collection_name: str):
 
         worker_subclasses = discover_base_worker_subclasses(module)
         for worker_subcls in worker_subclasses:
+            logger.info(f"Generating metadata for {worker_subcls.type}")
             output[worker_subcls.type] = generate_worker_metadata(
                 worker_subcls=worker_subcls, package_name=collection_name
             )


### PR DESCRIPTION
we were not filtering out the worker types (`BlockWorker` in this case) for the core worker metadata generation