### PR TITLE
Use one GitHub token per repo + permission

### DIFF
--- a/src/prefect_collection_registry/cli.py
+++ b/src/prefect_collection_registry/cli.py
@@ -1,11 +1,9 @@
 import asyncio
-import os
 import sys
 from typing import NoReturn
 from uuid import UUID
 
 from prefect import get_client
-from prefect.blocks.system import Secret
 from prefect.context import FlowRunContext
 from prefect.results import ResultStore
 from prefect.task_runners import ThreadPoolTaskRunner
@@ -28,7 +26,6 @@ async def run_all_collections(branch_name: str = "update-metadata") -> None:
 
 def main() -> NoReturn:
     """CLI entrypoint."""
-    os.environ["GITHUB_TOKEN"] = Secret.load("gh-util-token", _sync=True).get()  # type: ignore
     if len(sys.argv) == 1:
         # No args - run all collections
         asyncio.run(run_all_collections())

--- a/src/prefect_collection_registry/generate_block_metadata.py
+++ b/src/prefect_collection_registry/generate_block_metadata.py
@@ -154,7 +154,12 @@ def write_block_metadata(collection_metadata: dict[str, Any], collection_name: s
 
 
 @task(name="update-block-metadata-for-collection")
-async def update_block_metadata_for_collection(collection_name: str, branch_name: str):
+async def update_block_metadata_for_collection(
+    collection_name: str,
+    branch_name: str,
+    registry_contents_token: str,
+    prefect_contents_token: str,
+):
     """Generates and submits block metadata for a given collection."""
     block_metadata = generate_block_metadata_for_collection(collection_name)
     await utils.submit_updates(
@@ -162,4 +167,6 @@ async def update_block_metadata_for_collection(collection_name: str, branch_name
         collection_name=collection_name,
         branch_name=branch_name,
         variety="block",
+        registry_contents_token=registry_contents_token,
+        prefect_contents_token=prefect_contents_token,
     )

--- a/src/prefect_collection_registry/generate_flow_metadata.py
+++ b/src/prefect_collection_registry/generate_flow_metadata.py
@@ -112,7 +112,12 @@ def generate_flow_metadata(collection_name: str) -> dict[str, Any]:
 
 
 @task(name="update-flow-metadata-for-collection")
-async def update_flow_metadata_for_collection(collection_name: str, branch_name: str):
+async def update_flow_metadata_for_collection(
+    collection_name: str,
+    branch_name: str,
+    registry_contents_token: str,
+    prefect_contents_token: str,
+):
     """Generates and submits flow metadata for a given collection."""
     if collection_name == "prefect":
         return Completed(message="No flow metadata to update for Prefect core.")
@@ -123,4 +128,6 @@ async def update_flow_metadata_for_collection(collection_name: str, branch_name:
         collection_name=collection_name,
         branch_name=branch_name,
         variety="flow",
+        registry_contents_token=registry_contents_token,
+        prefect_contents_token=prefect_contents_token,
     )

--- a/src/prefect_collection_registry/generate_worker_metadata.py
+++ b/src/prefect_collection_registry/generate_worker_metadata.py
@@ -154,7 +154,12 @@ def generate_worker_metadata_for_package(package_name: str) -> dict[str, Any]:
 
 
 @task
-async def update_worker_metadata_for_package(package_name: str, branch_name: str):
+async def update_worker_metadata_for_package(
+    package_name: str,
+    branch_name: str,
+    registry_contents_token: str,
+    prefect_contents_token: str,
+):
     """Generates and submits worker metadata for a given package."""
     worker_metadata = generate_worker_metadata_for_package(package_name=package_name)
     await submit_updates(
@@ -162,6 +167,8 @@ async def update_worker_metadata_for_package(package_name: str, branch_name: str
         collection_name=package_name,
         branch_name=branch_name,
         variety="worker",
+        registry_contents_token=registry_contents_token,
+        prefect_contents_token=prefect_contents_token,
     )
 
 

--- a/src/prefect_collection_registry/sync_views_to_core.py
+++ b/src/prefect_collection_registry/sync_views_to_core.py
@@ -20,7 +20,7 @@ PREFECT_ACTIONS_SECRET = "prefect-actions-rw"
 
 
 async def _load_secret(name: str) -> str:
-    block = await Secret[str].aload(name)  # type: ignore[misc]
+    block = await Secret.aload(name)  # type: ignore[misc]
     return block.get()
 
 

--- a/src/prefect_collection_registry/sync_views_to_core.py
+++ b/src/prefect_collection_registry/sync_views_to_core.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from datetime import datetime
 
 from prefect import flow
@@ -13,6 +12,17 @@ from prefect_collection_registry.utils import (
     get_file_contents,
 )
 
+# Secret block names. The source repo is the registry; the target repo is
+# `PrefectHQ/prefect`, and the only writes here are to the prefect repo.
+REGISTRY_CONTENTS_SECRET = "prefect-collection-registry-contents-rw"
+PREFECT_CONTENTS_SECRET = "prefect-contents-rw"
+PREFECT_ACTIONS_SECRET = "prefect-actions-rw"
+
+
+async def _load_secret(name: str) -> str:
+    block = await Secret[str].aload(name)  # type: ignore[misc]
+    return block.get()
+
 
 @flow
 async def sync_worker_metadata_to_core(
@@ -25,27 +35,42 @@ async def sync_worker_metadata_to_core(
     """Syncs the worker metadata view to the Prefect core repository.
     Creates a new branch and PR if changes are detected.
     """
+    registry_contents_token = await _load_secret(REGISTRY_CONTENTS_SECRET)
+    prefect_contents_token = await _load_secret(PREFECT_CONTENTS_SECRET)
+    prefect_actions_token = await _load_secret(PREFECT_ACTIONS_SECRET)
+
     # Generate unique branch name
     new_branch = f"update-worker-metadata-{datetime.now().strftime('%Y%m%d%H%M%S')}"
 
     # Get the content from our repo
     content, _ = await get_file_contents(
-        source_repo_owner, source_repo, view_path, "main"
+        source_repo_owner,
+        source_repo,
+        view_path,
+        "main",
+        token=registry_contents_token,
     )
 
     # Create new branch in target repo
-    main_sha = await get_commit_sha(source_repo_owner, target_repo, "main")
+    main_sha = await get_commit_sha(
+        source_repo_owner, target_repo, "main", token=prefect_contents_token
+    )
     await create_repo_ref(
         source_repo_owner,
         target_repo,
         f"refs/heads/{new_branch}",
         main_sha,
+        token=prefect_contents_token,
     )
 
     # Get the SHA of the existing file in the target repo
     try:
         _, target_file_sha = await get_file_contents(
-            source_repo_owner, target_repo, target_path, new_branch
+            source_repo_owner,
+            target_repo,
+            target_path,
+            new_branch,
+            token=prefect_contents_token,
         )
     except Exception as e:
         if "Not Found" in str(e):
@@ -61,19 +86,20 @@ async def sync_worker_metadata_to_core(
         "Update aggregate-worker-metadata.json",
         content,
         new_branch,
+        token=prefect_contents_token,
         sha=target_file_sha,
     )
 
-    # Create PR
+    # Create PR (no labels, so no Issues token is needed)
     await create_pull_request(
         source_repo_owner,
         target_repo,
         "Automated PR for Worker Metadata Update",
         "This is an automated PR to update the worker metadata.",
         new_branch,
+        pulls_token=prefect_actions_token,
     )
 
 
 if __name__ == "__main__":
-    os.environ["GITHUB_TOKEN"] = Secret.load("gh-util-token").get()  # type: ignore
     asyncio.run(sync_worker_metadata_to_core())

--- a/src/prefect_collection_registry/update_collection_metadata.py
+++ b/src/prefect_collection_registry/update_collection_metadata.py
@@ -29,7 +29,6 @@ from prefect_collection_registry.utils import (
 # Secret block names. Each token is scoped to a single (repo, permission).
 REGISTRY_CONTENTS_SECRET = "prefect-collection-registry-contents-rw"
 REGISTRY_PRS_SECRET = "prefect-collection-registry-prs-rw"
-REGISTRY_ISSUES_SECRET = "prefect-collection-registry-issues-rw"
 PREFECT_CONTENTS_SECRET = "prefect-contents-rw"
 
 
@@ -239,7 +238,6 @@ async def update_all_collections(
     """Updates all collections for releases and updates the metadata if needed."""
     registry_contents_token = await _load_secret(REGISTRY_CONTENTS_SECRET)
     registry_prs_token = await _load_secret(REGISTRY_PRS_SECRET)
-    registry_issues_token = await _load_secret(REGISTRY_ISSUES_SECRET)
     prefect_contents_token = await _load_secret(PREFECT_CONTENTS_SECRET)
 
     if branch_name == "update-metadata":  # avoid overwriting existing branches
@@ -304,6 +302,9 @@ async def update_all_collections(
             f"\n\nNote: Updates failed for: {listrepr(failed_collections)}"
         )
 
+    # Labelling a PR via /issues/{n}/labels needs Pull requests: R&W on a
+    # fine-grained PAT (the URL says "issues" but the resource is a PR), so
+    # we reuse the PRs token here rather than the issues-only one.
     await create_pull_request(
         "PrefectHQ",
         "prefect-collection-registry",
@@ -312,7 +313,7 @@ async def update_all_collections(
         branch_name,
         pulls_token=registry_prs_token,
         labels=["automated-pr", "collection-metadata"],
-        labels_token=registry_issues_token,
+        labels_token=registry_prs_token,
     )
     print(f"Created PR for branch {branch_name}")
 

--- a/src/prefect_collection_registry/update_collection_metadata.py
+++ b/src/prefect_collection_registry/update_collection_metadata.py
@@ -34,7 +34,7 @@ PREFECT_CONTENTS_SECRET = "prefect-contents-rw"
 
 
 async def _load_secret(name: str) -> str:
-    block = await Secret[str].aload(name)  # type: ignore[misc]
+    block = await Secret.aload(name)  # type: ignore[misc]
     return block.get()
 
 

--- a/src/prefect_collection_registry/update_collection_metadata.py
+++ b/src/prefect_collection_registry/update_collection_metadata.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from typing import Any
 
 import prefect.runtime.flow_run
@@ -27,6 +26,18 @@ from prefect_collection_registry.utils import (
     get_repo_contents,
 )
 
+# Secret block names. Each token is scoped to a single (repo, permission).
+REGISTRY_CONTENTS_SECRET = "prefect-collection-registry-contents-rw"
+REGISTRY_ACTIONS_SECRET = "prefect-collection-registry-actions-rw"
+REGISTRY_ISSUES_SECRET = "prefect-collection-registry-issues-rw"
+PREFECT_CONTENTS_SECRET = "prefect-contents-rw"
+
+
+async def _load_secret(name: str) -> str:
+    block = await Secret[str].aload(name)  # type: ignore[misc]
+    return block.get()
+
+
 TODO_COLLECTIONS = {
     "prefect-sqlalchemy",
 }
@@ -41,13 +52,18 @@ and will trigger a run of `update_collection_metadata` for each such package.
 """
 
 
-async def collection_needs_update(collection_name: str) -> tuple[str, bool]:
+async def collection_needs_update(
+    collection_name: str,
+    registry_contents_token: str,
+    prefect_contents_token: str,
+) -> tuple[str, bool]:
     """Checks if the collection needs to be updated."""
     try:
         registry_contents = await get_repo_contents(
             "PrefectHQ",
             "prefect-collection-registry",
             f"collections/{collection_name}/blocks",
+            token=registry_contents_token,
             ref="main",
         )
         if not registry_contents:
@@ -57,7 +73,9 @@ async def collection_needs_update(collection_name: str) -> tuple[str, bool]:
             [content["name"] for content in registry_contents]
         )[-1].replace(".json", "")
 
-        latest_release = await get_latest_pypi_release(collection_name)
+        latest_release = await get_latest_pypi_release(
+            collection_name, prefect_contents_token=prefect_contents_token
+        )
 
         if latest_release == latest_recorded_release:
             print(
@@ -75,20 +93,29 @@ async def collection_needs_update(collection_name: str) -> tuple[str, bool]:
 
 
 @task(name="Create Branch / PR if possible")
-async def create_ref_if_not_exists(new_branch_name: str) -> str:
+async def create_ref_if_not_exists(
+    new_branch_name: str, registry_contents_token: str
+) -> str:
     """Creates a branch if it doesn't already exist."""
     # Check if branch exists first
     if not await branch_exists(
-        "PrefectHQ", "prefect-collection-registry", new_branch_name
+        "PrefectHQ",
+        "prefect-collection-registry",
+        new_branch_name,
+        token=registry_contents_token,
     ):
         main_sha = await get_commit_sha(
-            "PrefectHQ", "prefect-collection-registry", "main"
+            "PrefectHQ",
+            "prefect-collection-registry",
+            "main",
+            token=registry_contents_token,
         )
         await create_repo_ref(
             "PrefectHQ",
             "prefect-collection-registry",
             f"refs/heads/{new_branch_name}",
             main_sha,
+            token=registry_contents_token,
         )
         print(f"Created ref {new_branch_name!r}!")
     else:
@@ -101,10 +128,28 @@ async def update_collection_metadata(
     collection_name: str,
     branch_name: str,
 ) -> State:
-    """Updates each variety of metadata for a given package."""
+    """Updates each variety of metadata for a given package.
+
+    Tokens are loaded inside this entrypoint because it is invoked as a
+    subprocess by `run_collection_update`, so the parent flow's already-loaded
+    secrets do not survive the process boundary.
+    """
+    registry_contents_token = await _load_secret(REGISTRY_CONTENTS_SECRET)
+    prefect_contents_token = await _load_secret(PREFECT_CONTENTS_SECRET)
+
     # Run updates sequentially to avoid conflicts in aggregate files
-    await update_block_metadata_for_collection(collection_name, branch_name)
-    await update_worker_metadata_for_package(collection_name, branch_name)
+    await update_block_metadata_for_collection(
+        collection_name,
+        branch_name,
+        registry_contents_token=registry_contents_token,
+        prefect_contents_token=prefect_contents_token,
+    )
+    await update_worker_metadata_for_package(
+        collection_name,
+        branch_name,
+        registry_contents_token=registry_contents_token,
+        prefect_contents_token=prefect_contents_token,
+    )
 
     return Completed(message=f"Successfully updated {collection_name}")
 
@@ -192,23 +237,37 @@ async def update_all_collections(
     include_collections: list[str] | None = None,
 ):
     """Updates all collections for releases and updates the metadata if needed."""
-    os.environ["GITHUB_TOKEN"] = (await Secret.aload("gh-util-token")).get()  # type: ignore
+    registry_contents_token = await _load_secret(REGISTRY_CONTENTS_SECRET)
+    registry_actions_token = await _load_secret(REGISTRY_ACTIONS_SECRET)
+    registry_issues_token = await _load_secret(REGISTRY_ISSUES_SECRET)
+    prefect_contents_token = await _load_secret(PREFECT_CONTENTS_SECRET)
 
     if branch_name == "update-metadata":  # avoid overwriting existing branches
         branch_name = f"update-metadata-{DateTime.now().format('MM-DD-YYYY-HH-MM-SS')}"
 
     # First close any old PRs before creating our new one
-    await close_old_metadata_prs()
+    await close_old_metadata_prs(
+        contents_token=registry_contents_token,
+        pulls_token=registry_actions_token,
+    )
 
     # Create branch
-    branch_name = await create_ref_if_not_exists(branch_name)
+    branch_name = await create_ref_if_not_exists(
+        branch_name, registry_contents_token=registry_contents_token
+    )
 
     collections_to_update = set(
         collection_name
         for collection_name, needs_update in await asyncio.gather(
             *[
-                collection_needs_update(collection_name)
-                for collection_name in await get_collection_names()
+                collection_needs_update(
+                    collection_name,
+                    registry_contents_token=registry_contents_token,
+                    prefect_contents_token=prefect_contents_token,
+                )
+                for collection_name in await get_collection_names(
+                    token=prefect_contents_token
+                )
             ]
         )
         if needs_update
@@ -251,7 +310,9 @@ async def update_all_collections(
         "Update metadata for collection releases",
         pr_description,
         branch_name,
+        pulls_token=registry_actions_token,
         labels=["automated-pr", "collection-metadata"],
+        labels_token=registry_issues_token,
     )
     print(f"Created PR for branch {branch_name}")
 

--- a/src/prefect_collection_registry/update_collection_metadata.py
+++ b/src/prefect_collection_registry/update_collection_metadata.py
@@ -28,7 +28,7 @@ from prefect_collection_registry.utils import (
 
 # Secret block names. Each token is scoped to a single (repo, permission).
 REGISTRY_CONTENTS_SECRET = "prefect-collection-registry-contents-rw"
-REGISTRY_ACTIONS_SECRET = "prefect-collection-registry-actions-rw"
+REGISTRY_PRS_SECRET = "prefect-collection-registry-prs-rw"
 REGISTRY_ISSUES_SECRET = "prefect-collection-registry-issues-rw"
 PREFECT_CONTENTS_SECRET = "prefect-contents-rw"
 
@@ -238,7 +238,7 @@ async def update_all_collections(
 ):
     """Updates all collections for releases and updates the metadata if needed."""
     registry_contents_token = await _load_secret(REGISTRY_CONTENTS_SECRET)
-    registry_actions_token = await _load_secret(REGISTRY_ACTIONS_SECRET)
+    registry_prs_token = await _load_secret(REGISTRY_PRS_SECRET)
     registry_issues_token = await _load_secret(REGISTRY_ISSUES_SECRET)
     prefect_contents_token = await _load_secret(PREFECT_CONTENTS_SECRET)
 
@@ -248,7 +248,7 @@ async def update_all_collections(
     # First close any old PRs before creating our new one
     await close_old_metadata_prs(
         contents_token=registry_contents_token,
-        pulls_token=registry_actions_token,
+        pulls_token=registry_prs_token,
     )
 
     # Create branch
@@ -310,7 +310,7 @@ async def update_all_collections(
         "Update metadata for collection releases",
         pr_description,
         branch_name,
-        pulls_token=registry_actions_token,
+        pulls_token=registry_prs_token,
         labels=["automated-pr", "collection-metadata"],
         labels_token=registry_issues_token,
     )

--- a/src/prefect_collection_registry/utils.py
+++ b/src/prefect_collection_registry/utils.py
@@ -503,8 +503,15 @@ async def close_old_metadata_prs(
                 pr["head"]["ref"].startswith("update-metadata-")
                 and pr["head"]["ref"] != latest_branch
             ):
-                await pulls_client.patch(
-                    f"/repos/{repo_owner}/{repo_name}/pulls/{pr['number']}",
-                    json={"state": "closed"},
-                )
-                print(f"Closed PR #{pr['number']}: {pr['title']}")
+                try:
+                    await pulls_client.patch(
+                        f"/repos/{repo_owner}/{repo_name}/pulls/{pr['number']}",
+                        json={"state": "closed"},
+                    )
+                    print(f"Closed PR #{pr['number']}: {pr['title']}")
+                except httpx.HTTPStatusError as e:
+                    # PR may have been closed between the list and the patch.
+                    if e.response.status_code == 422:
+                        print(f"PR #{pr['number']} already closed")
+                    else:
+                        raise

--- a/src/prefect_collection_registry/utils.py
+++ b/src/prefect_collection_registry/utils.py
@@ -12,9 +12,7 @@ from typing import Any, Literal
 import fastjsonschema
 import httpx
 from gh_util.client import GHClient
-from gh_util.types import GitHubRepo
 from prefect import Flow, task
-from prefect.blocks.system import Secret
 from prefect.utilities.importtools import load_module, to_qualified_name
 from pydantic_core import from_json
 
@@ -23,6 +21,18 @@ CollectionViewVariety = Literal["block", "flow", "worker"]
 # Create a lock file in a location accessible to all processes
 LOCK_FILE = os.path.join(tempfile.gettempdir(), "prefect_collection_registry.lock")
 _file_lock = Lock()
+
+
+def _gh_client(token: str) -> GHClient:
+    """Build a GHClient that authenticates with the given token.
+
+    Bypasses gh_util's GITHUB_TOKEN env-var lookup so each call site can
+    pick a token scoped to the specific repo + permission it needs.
+    """
+    client = GHClient()
+    client.headers["Authorization"] = f"token {token}"
+    client.headers.setdefault("Accept", "application/vnd.github.v3+json")
+    return client
 
 
 def skip_parsing(
@@ -65,10 +75,10 @@ def find_flows_in_module(
 
 
 async def get_file_contents(
-    repo_owner: str, repo_name: str, path: str, ref: str
+    repo_owner: str, repo_name: str, path: str, ref: str, token: str
 ) -> tuple[str, str]:
     """Get a file's contents and its SHA."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         response = await client.get(
             f"/repos/{repo_owner}/{repo_name}/contents/{path}", params={"ref": ref}
         )
@@ -84,10 +94,11 @@ async def create_or_update_file(
     message: str,
     content: str,
     branch: str,
+    token: str,
     sha: str | None = None,
 ) -> dict[str, Any]:
     """Create or update a file in a repository."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         data = {
             "message": message,
             "content": base64.b64encode(content.encode("utf-8")).decode("utf-8"),
@@ -102,11 +113,19 @@ async def create_or_update_file(
         return response.json()
 
 
-async def get_latest_pypi_release(package_name: str) -> str:
-    """Get the latest release version from PyPI for a package."""
-    # For prefect, we need to use the GitHub release
+async def get_latest_pypi_release(
+    package_name: str, prefect_contents_token: str
+) -> str:
+    """Get the latest release version from PyPI for a package.
+
+    For `prefect`, the version comes from the latest GitHub release on
+    `PrefectHQ/prefect` (so a contents-read token for that repo is required).
+    For other packages, the lookup is unauthenticated against PyPI.
+    """
     if package_name == "prefect":
-        latest_release = await get_latest_release("PrefectHQ", package_name)
+        latest_release = await get_latest_release(
+            "PrefectHQ", package_name, token=prefect_contents_token
+        )
         return (
             "v" + latest_release
             if not latest_release.startswith("v")
@@ -127,6 +146,8 @@ async def submit_updates(
     collection_name: str,
     branch_name: str,
     variety: CollectionViewVariety,
+    registry_contents_token: str,
+    prefect_contents_token: str,
     repo_name: str = "prefect-collection-registry",
 ) -> None:
     """Submits updates to the collection registry.
@@ -138,7 +159,9 @@ async def submit_updates(
     metadata_file = f"views/aggregate-{variety}-metadata.json"
 
     # Get latest release from PyPI instead of GitHub
-    latest_release = await get_latest_pypi_release(collection_name)
+    latest_release = await get_latest_pypi_release(
+        collection_name, prefect_contents_token=prefect_contents_token
+    )
 
     # First handle the version-specific file which can't have conflicts
     collection_version_path = (
@@ -149,7 +172,11 @@ async def submit_updates(
         # Get version file SHA
         try:
             _, version_sha = await get_file_contents(
-                "PrefectHQ", repo_name, collection_version_path, branch_name
+                "PrefectHQ",
+                repo_name,
+                collection_version_path,
+                branch_name,
+                token=registry_contents_token,
             )
         except Exception as e:
             if "Not Found" in str(e):
@@ -166,6 +193,7 @@ async def submit_updates(
                 f"Add `{collection_name}` `{latest_release}` to {variety} records",
                 json.dumps({collection_name: collection_metadata}, indent=2),
                 branch_name,
+                token=registry_contents_token,
                 sha=version_sha,
             )
             print(f"Added {collection_name} {latest_release} to {variety} records!")
@@ -184,7 +212,11 @@ async def submit_updates(
                 try:
                     # Get latest content and SHA
                     content, aggregate_sha = await get_file_contents(
-                        "PrefectHQ", repo_name, metadata_file, branch_name
+                        "PrefectHQ",
+                        repo_name,
+                        metadata_file,
+                        branch_name,
+                        token=registry_contents_token,
                     )
                     existing_metadata_dict: dict[str, Any] = from_json(content)
                 except Exception as e:
@@ -207,6 +239,7 @@ async def submit_updates(
                         f"Update aggregate {variety} metadata with `{collection_name}` `{latest_release}`",
                         json.dumps(updated_metadata_dict, indent=2),
                         branch_name,
+                        token=registry_contents_token,
                         sha=aggregate_sha,
                     )
                     print(
@@ -224,6 +257,7 @@ async def submit_updates(
 
 
 async def get_collection_names(
+    token: str,
     repo_owner: str = "PrefectHQ",
     repo_name: str = "prefect",
     path: str = "src/integrations",
@@ -234,12 +268,8 @@ async def get_collection_names(
     prefect monorepo (the standalone `prefect-*` repos are archived).
     Every directory there is a Prefect-authored integration.
     """
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            url=f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents/{path}",
-            headers={"Accept": "application/vnd.github+json"},
-        )
-        response.raise_for_status()
+    async with _gh_client(token) as client:
+        response = await client.get(f"/repos/{repo_owner}/{repo_name}/contents/{path}")
         entries = response.json()
 
     collections = [
@@ -275,35 +305,39 @@ def read_view_content(view: CollectionViewVariety) -> dict[str, Any]:
 
 
 async def get_repo_contents(
-    repo_owner: str, repo_name: str, path: str, ref: str = "main"
+    repo_owner: str,
+    repo_name: str,
+    path: str,
+    token: str,
+    ref: str = "main",
 ) -> list[dict[str, Any]]:
     """Get contents of a repository path."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         response = await client.get(
             f"/repos/{repo_owner}/{repo_name}/contents/{path}", params={"ref": ref}
         )
         return response.json()
 
 
-async def get_latest_release(repo_owner: str, repo_name: str) -> str:
+async def get_latest_release(repo_owner: str, repo_name: str, token: str) -> str:
     """Get the latest release tag for a repository."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         response = await client.get(f"/repos/{repo_owner}/{repo_name}/releases/latest")
         return response.json()["tag_name"]
 
 
-async def get_commit_sha(repo_owner: str, repo_name: str, ref: str) -> str:
+async def get_commit_sha(repo_owner: str, repo_name: str, ref: str, token: str) -> str:
     """Get the SHA for a given ref."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         response = await client.get(f"/repos/{repo_owner}/{repo_name}/commits/{ref}")
         return response.json()["sha"]
 
 
 async def create_repo_ref(
-    repo_owner: str, repo_name: str, ref: str, sha: str
+    repo_owner: str, repo_name: str, ref: str, sha: str, token: str
 ) -> dict[str, Any]:
     """Create a new git reference in a repository."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         response = await client.post(
             f"/repos/{repo_owner}/{repo_name}/git/refs", json={"ref": ref, "sha": sha}
         )
@@ -316,13 +350,26 @@ async def create_pull_request(
     title: str,
     body: str,
     head: str,
+    pulls_token: str,
     base: str = "main",
     labels: list[str] | None = None,
+    labels_token: str | None = None,
 ) -> dict[str, Any]:
-    """Create a pull request."""
+    """Create a pull request.
+
+    `pulls_token` needs Pull Requests: Read & Write on the target repo. If
+    `labels` is non-empty, `labels_token` must be provided and needs Issues:
+    Read & Write — labelling a PR goes through the issues endpoint.
+    """
     labels = labels or []
+    if labels and labels_token is None:
+        raise ValueError(
+            "labels_token is required when labels are provided; the issues "
+            "endpoint needs an Issues: Read & Write token."
+        )
+
     # First check if branches are different
-    async with GHClient() as client:
+    async with _gh_client(pulls_token) as client:
         # Compare branches
         response = await client.get(
             f"/repos/{repo_owner}/{repo_name}/compare/{base}...{head}"
@@ -346,25 +393,19 @@ async def create_pull_request(
                 },
             )
             data = response.json()
-            await client.post(
-                f"/repos/{repo_owner}/{repo_name}/issues/{data['number']}/labels",
-                json={"labels": labels},
-            )
-            return data
         except httpx.HTTPStatusError as e:
             if "A pull request already exists" in str(e):
                 print(f"PR from {head} to {base} already exists")
                 return {}
             raise
 
-
-async def get_repo(name: str) -> GitHubRepo:
-    """Returns a GitHub repository object for a given collection name."""
-    github_token = await Secret[str].aload("collection-registry-contents-prs-rw-pat")
-
-    async with GHClient(token=github_token.get()) as client:
-        response = await client.get(f"/repos/PrefectHQ/{name}")
-        return GitHubRepo.model_validate(response.json())
+    if labels:
+        async with _gh_client(labels_token) as labels_client:  # type: ignore[arg-type]
+            await labels_client.post(
+                f"/repos/{repo_owner}/{repo_name}/issues/{data['number']}/labels",
+                json={"labels": labels},
+            )
+    return data
 
 
 def validate_view_content(
@@ -387,9 +428,11 @@ def validate_view_content(
         print(f"  Validated {collection_name} summary in {variety} view!")
 
 
-async def branch_exists(repo_owner: str, repo_name: str, branch_name: str) -> bool:
+async def branch_exists(
+    repo_owner: str, repo_name: str, branch_name: str, token: str
+) -> bool:
     """Check if a branch exists."""
-    async with GHClient() as client:
+    async with _gh_client(token) as client:
         try:
             await client.get(f"/repos/{repo_owner}/{repo_name}/branches/{branch_name}")
             return True
@@ -400,15 +443,20 @@ async def branch_exists(repo_owner: str, repo_name: str, branch_name: str) -> bo
 
 
 async def close_old_metadata_prs(
+    contents_token: str,
+    pulls_token: str,
     repo_owner: str = "PrefectHQ",
     repo_name: str = "prefect-collection-registry",
 ) -> None:
     """Closes all metadata PRs except for the one associated with the latest branch.
     Also deletes all old metadata branches except the latest one.
+
+    Branch listing/deletion uses `contents_token` (Contents: R&W). PR listing
+    and patching uses `pulls_token` (Pull Requests: R&W).
     """
-    async with GHClient() as client:
-        # Get all branches to find the latest
-        branches_response = await client.get(
+    # Branch operations use the contents token.
+    async with _gh_client(contents_token) as contents_client:
+        branches_response = await contents_client.get(
             f"/repos/{repo_owner}/{repo_name}/branches"
         )
         metadata_branches = [
@@ -432,7 +480,7 @@ async def close_old_metadata_prs(
         for branch in metadata_branches:
             if branch != latest_branch:
                 try:
-                    await client.delete(
+                    await contents_client.delete(
                         f"/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
                     )
                     print(f"Deleted branch {branch}")
@@ -442,8 +490,9 @@ async def close_old_metadata_prs(
                     else:
                         raise
 
-        # Get all open PRs and close them if they're for metadata branches
-        response = await client.get(
+    # PR operations use the pulls token.
+    async with _gh_client(pulls_token) as pulls_client:
+        response = await pulls_client.get(
             f"/repos/{repo_owner}/{repo_name}/pulls",
             params={"state": "open"},
         )
@@ -454,7 +503,7 @@ async def close_old_metadata_prs(
                 pr["head"]["ref"].startswith("update-metadata-")
                 and pr["head"]["ref"] != latest_branch
             ):
-                await client.patch(
+                await pulls_client.patch(
                     f"/repos/{repo_owner}/{repo_name}/pulls/{pr['number']}",
                     json={"state": "closed"},
                 )


### PR DESCRIPTION
## Summary

Replaces the single shared `gh-util-token` Prefect Secret (whose underlying
PAT is broadly scoped) with four narrowly-scoped Secret blocks, one per
(repo, permission) pair. 

Related to https://linear.app/prefect/issue/PLA-2673/update-token-for-prefect-collection-registry-flow

### Token mapping

| Secret block | Repo | Fine-grained PAT permissions |
|---|---|---|
| `prefect-collection-registry-contents-rw` | `PrefectHQ/prefect-collection-registry` | Contents: R&W (covers commits, branches, refs, file CRUD, releases) |
| `prefect-collection-registry-prs-rw`      | `PrefectHQ/prefect-collection-registry` | Pull requests: R&W (PR list / create / patch, **and PR labelling** — see note below) |
| `prefect-contents-rw` (pre-existing)      | `PrefectHQ/prefect` | Contents: R&W (commits, refs, file write, release lookup, integrations dir read) |
| `prefect-actions-rw`  (pre-existing)      | `PrefectHQ/prefect` | Pull requests: R&W (PR creation in `sync_worker_metadata_to_core`) |

All fine-grained PATs additionally need the implicit `Metadata: Read`.

### Note on the PR-labelling endpoint

GitHub exposes PR labelling via `POST /repos/{owner}/{repo}/issues/{n}/labels`.
The URL path says "issues", but when the underlying resource is a pull
request, fine-grained PATs require **Pull requests: Read & Write** on the
target repo — Issues: R&W alone is not sufficient and returns
`403 "Resource not accessible by personal access token"`. We confirmed this
empirically against a separately-issued `prefect-collection-registry-issues-rw`
PAT during testing. Because the PRs token already has the right scope and
is used to create the PR moments earlier, this PR routes the labelling call
through the PRs token as well, and does not introduce a separate issues PAT.

The helper `create_pull_request` still keeps a separate `labels_token`
parameter so that future callers can split the two if they want, but for the
metadata flow both are the PRs token.

### Mechanics

* `utils.py` gains a `_gh_client(token)` factory that constructs a `GHClient`
  and overrides the `Authorization` header explicitly, bypassing
  `gh_util.settings.token` and the `GITHUB_TOKEN` env var. Each helper
  (`get_file_contents`, `create_or_update_file`, `get_repo_contents`,
  `branch_exists`, `get_commit_sha`, `create_repo_ref`, `get_latest_release`,
  `get_collection_names`, `submit_updates`, `create_pull_request`,
  `close_old_metadata_prs`) now takes an explicit `token` argument.
* `create_pull_request` splits authentication: `pulls_token` for the pulls
  endpoint and `labels_token` for the issues/labels endpoint. In this flow
  the same PRs token is passed for both (see note above).
* `close_old_metadata_prs` takes both a contents token (for branch list /
  delete via `/git/refs/heads/...`) and a pulls token (for list / patch
  PRs). It now also swallows `422` on PR-state PATCHes the same way it
  swallows `404` on branch deletes — handles the case where a PR closes
  between the list-open call and the patch.
* `get_collection_names` is now authenticated using `prefect-contents-rw`,
  replacing the prior unauthenticated `httpx` call to `api.github.com`. This
  gives us a higher rate limit and consistent auditing.
* Removed the unused `get_repo` helper and its reference to the legacy
  `collection-registry-contents-prs-rw-pat` Secret.
* `update_collection_metadata` (run as a CLI subprocess) loads its own tokens
  inside the entrypoint, since secrets loaded by the parent flow do not
  cross the process boundary. The parent `update_all_collections` flow
  loads all three needed tokens once at the top and threads them through.
* `cli.py` and `sync_views_to_core.py` no longer set `GITHUB_TOKEN` from
  `gh-util-token`.

### Notes for the deploy

Once this is merged the `gh-util-token` and `collection-registry-contents-prs-rw-pat`
Secret blocks can be deleted (the latter is already orphaned in `main`).
The `prefect-collection-registry-issues-rw` Secret block created during
investigation is also unused by this flow — safe to delete.

## Test plan

- [x] `uv run pytest tests/` — 6 passed, 1 xfailed (pre-existing)
- [x] Manual: ran `update-all-collections` end-to-end. Old-PR cleanup, new
      branch creation, version + aggregate file PUTs, PR creation, and
      PR labelling all succeeded with their respective tokens. Per-collection
      failures observed are pre-existing (same set as the most recent run on
      `main`, PR #1018) and unrelated to the token split.
- [x] Manual: run `sync_worker_metadata_to_core` and confirm the PR is
      opened in `PrefectHQ/prefect` using `prefect-contents-rw` +
      `prefect-actions-rw`. -> I'm fairly sure this workflow is unchanged anyway

Also got a successful run here, although some work 'failed' https://app.prefect.cloud/account/12242a57-9f05-4bf5-8853-9bff595d4bab/workspace/0c1c7570-6dd1-4d97-ba23-0d6753febd42/runs/flow-run/069f9079-85a3-739b-8000-da3eeacae8e7?preview=true&tab=logs.

This is a manual prefect deploy from this PR.