### PR TITLE
ci: read GHA_WORKLOAD_IDENTITY_PROVIDER from vars instead of secrets

### DIFF
--- a/.github/workflows/prefect-deploy.yml
+++ b/.github/workflows/prefect-deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          workload_identity_provider: ${{ secrets.GHA_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ vars.GHA_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: collection-registry-gen-main@prefect-org-github-actions.iam.gserviceaccount.com
 
       - name: Configure Google Cloud credential helper


### PR DESCRIPTION
## Summary

- Switch `prefect-deploy.yml` to read `GHA_WORKLOAD_IDENTITY_PROVIDER` from `vars` instead of `secrets`, matching the convention used across the rest of the PrefectHQ org (nebula, nebula-ui, flows, platform, prefect-bot, mex-aws-token-injector, etc.).
- The repo currently has no secret or org-secret named `GHA_WORKLOAD_IDENTITY_PROVIDER` accessible to it, so the GCP auth step fails as written.

Related to https://linear.app/prefect/issue/PLA-2673/update-token-for-prefect-collection-registry-flow

## Follow-up (org admin)

The org-level Actions variable `GHA_WORKLOAD_IDENTITY_PROVIDER` must be made accessible to `prefect-collection-registry` for this workflow to authenticate. Add this repo to the variable's selected-repositories list (or set it to "all repositories").

## Test plan

- [ ] Org admin grants this repo access to the `GHA_WORKLOAD_IDENTITY_PROVIDER` org variable
- [ ] Re-run the `prefect-deploy` workflow and confirm the `Authenticate to Google Cloud` step succeeds