### PR TITLE
Add prefect-xquik collection metadata

### DIFF
--- a/collections/prefect-xquik/blocks/v0.1.6.json
+++ b/collections/prefect-xquik/blocks/v0.1.6.json
@@ -1,0 +1,64 @@
+{
+  "prefect-xquik": {
+    "block_types": {
+      "xquik-credentials": {
+        "name": "Xquik Credentials",
+        "slug": "xquik-credentials",
+        "logo_url": "https://xquik.com/icon.svg",
+        "documentation_url": "https://docs.xquik.com/guides/prefect",
+        "description": "Block used to authenticate Xquik API requests. This block is part of the prefect-xquik collection. Install prefect-xquik with `pip install prefect-xquik` to use this block.",
+        "code_example": "```python\nfrom prefect_xquik.credentials import XquikCredentials\n\nxquik_credentials_block = XquikCredentials.load(\"BLOCK_NAME\")\n```",
+        "block_schema": {
+          "checksum": "sha256:b98225d0f98db1939af99b0c2f88099d423135a2b1fdf3ebe5b4cd6578c0aaf2",
+          "fields": {
+            "block_schema_references": {},
+            "block_type_slug": "xquik-credentials",
+            "description": "Block used to authenticate Xquik API requests.",
+            "properties": {
+              "api_key": {
+                "description": "Xquik API key.",
+                "format": "password",
+                "title": "Api Key",
+                "type": "string",
+                "writeOnly": true,
+                "position": 0
+              },
+              "base_url": {
+                "default": "https://api.xquik.com",
+                "description": "Base URL for the Xquik API.",
+                "title": "Base Url",
+                "type": "string",
+                "position": 1
+              },
+              "api_contract": {
+                "default": "2026-04-29",
+                "description": "Xquik API contract date sent with requests.",
+                "title": "Api Contract",
+                "type": "string",
+                "position": 2
+              },
+              "timeout_seconds": {
+                "default": 30.0,
+                "description": "Request timeout in seconds.",
+                "exclusiveMinimum": 0,
+                "title": "Timeout Seconds",
+                "type": "number",
+                "position": 3
+              }
+            },
+            "required": [
+              "api_key"
+            ],
+            "secret_fields": [
+              "api_key"
+            ],
+            "title": "XquikCredentials",
+            "type": "object"
+          },
+          "capabilities": [],
+          "version": "0.1.6"
+        }
+      }
+    }
+  }
+}

--- a/collections/prefect-xquik/workers/v0.1.6.json
+++ b/collections/prefect-xquik/workers/v0.1.6.json
@@ -1,0 +1,3 @@
+{
+  "prefect-xquik": {}
+}

--- a/views/aggregate-block-metadata.json
+++ b/views/aggregate-block-metadata.json
@@ -5293,5 +5293,67 @@
         }
       }
     }
+  },
+  "prefect-xquik": {
+    "block_types": {
+      "xquik-credentials": {
+        "name": "Xquik Credentials",
+        "slug": "xquik-credentials",
+        "logo_url": "https://xquik.com/icon.svg",
+        "documentation_url": "https://docs.xquik.com/guides/prefect",
+        "description": "Block used to authenticate Xquik API requests. This block is part of the prefect-xquik collection. Install prefect-xquik with `pip install prefect-xquik` to use this block.",
+        "code_example": "```python\nfrom prefect_xquik.credentials import XquikCredentials\n\nxquik_credentials_block = XquikCredentials.load(\"BLOCK_NAME\")\n```",
+        "block_schema": {
+          "checksum": "sha256:b98225d0f98db1939af99b0c2f88099d423135a2b1fdf3ebe5b4cd6578c0aaf2",
+          "fields": {
+            "block_schema_references": {},
+            "block_type_slug": "xquik-credentials",
+            "description": "Block used to authenticate Xquik API requests.",
+            "properties": {
+              "api_key": {
+                "description": "Xquik API key.",
+                "format": "password",
+                "title": "Api Key",
+                "type": "string",
+                "writeOnly": true,
+                "position": 0
+              },
+              "base_url": {
+                "default": "https://api.xquik.com",
+                "description": "Base URL for the Xquik API.",
+                "title": "Base Url",
+                "type": "string",
+                "position": 1
+              },
+              "api_contract": {
+                "default": "2026-04-29",
+                "description": "Xquik API contract date sent with requests.",
+                "title": "Api Contract",
+                "type": "string",
+                "position": 2
+              },
+              "timeout_seconds": {
+                "default": 30.0,
+                "description": "Request timeout in seconds.",
+                "exclusiveMinimum": 0,
+                "title": "Timeout Seconds",
+                "type": "number",
+                "position": 3
+              }
+            },
+            "required": [
+              "api_key"
+            ],
+            "secret_fields": [
+              "api_key"
+            ],
+            "title": "XquikCredentials",
+            "type": "object"
+          },
+          "capabilities": [],
+          "version": "0.1.6"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds `prefect-xquik` collection metadata for the published `v0.1.6` release:

- adds `collections/prefect-xquik/blocks/v0.1.6.json`
- adds `collections/prefect-xquik/workers/v0.1.6.json` with no workers
- updates `views/aggregate-block-metadata.json` with the `xquik-credentials` block

The block metadata was generated with the registry metadata code against `prefect-xquik==0.1.6` from PyPI.

## Source and duplicate checks

- PyPI confirms `prefect-xquik` latest is `0.1.6`.
- `Xquik-dev/prefect-xquik` release `v0.1.6` exists and its publish workflow completed successfully.
- Searched open and closed PRs/issues in this repo for `prefect-xquik`, `Xquik`, and `x-twitter-scraper`; no existing submission was found.
- Confirmed `collections/prefect-xquik` and aggregate `prefect-xquik` entries were absent on `main` before this change.

## Validation

- `python3 -m json.tool collections/prefect-xquik/blocks/v0.1.6.json`
- `python3 -m json.tool collections/prefect-xquik/workers/v0.1.6.json`
- `python3 -m json.tool views/aggregate-block-metadata.json`
- `uv run --python 3.12 src/prefect_collection_registry/view_schema_validation.py`
- `UV_PYTHON=3.12 uvx pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

Note: a first local validation attempt used Python 3.14 by default and failed while building the target repo's pinned `greenlet` dependency. The successful validation above uses Python 3.12, matching this repo's pre-commit workflow.
