### PR TITLE
Install prefect-github in per-collection subprocess venv

### DIFF
--- a/src/prefect_collection_registry/update_collection_metadata.py
+++ b/src/prefect_collection_registry/update_collection_metadata.py
@@ -183,6 +183,8 @@ async def run_collection_update(collection_name: str, branch_name: str) -> str:
         "--upgrade",
         "--with",
         f"{collection_name}",
+        "--with",
+        "prefect-github<0.4.1",
         "src/prefect_collection_registry/cli.py",
         collection_name,
         branch_name,


### PR DESCRIPTION
## Summary

The first scheduled run of \`update-all-collections\` after PrefectHQ/prefect-collection-registry#1192 merged failed for ~16 of the 21 collections with a generic \`RuntimeError: Failed to update {name}\`. Root cause: the per-collection subprocess invocation runs \`uv run --isolated --with {collection_name}\` which creates a fresh venv that inherits nothing from the parent project. That venv didn't have \`prefect-github\` installed, so the lazy \`from prefect_github import GitHubCredentials\` inside \`_load_registry_writer_token()\` raised ImportError. The error was caught by the broad except in \`run_collection_update\` and surfaced as the unhelpful "Failed to update" message.

Adds \`--with prefect-github<0.4.1\` to the subprocess so every per-collection venv has it (pin matches PrefectHQ/prefect-collection-registry#1192 / pyproject.toml).

## Test plan

- [x] Trigger \`update-all-collections\` from the UI; verify all per-collection subprocesses succeed (or at least don't fail with the writer-token ImportError).
